### PR TITLE
feat: add --skip-lockfile flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "colored",
  "ignore",
  "nom",
+ "regex",
  "term-table",
 ]
 
@@ -238,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,5 @@ clap = { version = "4.5.1", features = ["cargo"] }
 colored = "2.1.0"
 ignore = "0.4.22"
 nom = "7.1.3"
+regex = "1.10.4"
 term-table = "1.3.2"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ code-peek [FLAGS] [OPTIONS] [ARGS]
 - _-a, --all_: Display all available information.
 - _-g, --group_: Group the results by file extension or programming language.
 - _-t, --git_: Get Git information (number of commits) for each file.
+- _--skip-lockfiles_: Skips lockfiles in analysis.
 
 ### Options
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ pub struct DisplayOptions {
     pub group: bool,
     pub git: bool,
     pub all: bool,
+    pub skip_lockfiles: bool,
 }
 
 pub fn run_cli() -> Result<Cli> {
@@ -37,6 +38,7 @@ pub fn run_cli() -> Result<Cli> {
     )
     .arg(arg!([all] -a --all "Display all available information").required(false))
     .arg(arg!([group] -g --group "Group the results by its extension").required(false))
+    .arg(arg!(--"skip-lockfiles" "Skips lockfiles in analysis").long("skip-lockfiles").required(false))
     .arg(arg!([git] -t --git "Get git info - how many commits were made to each file").required(false))
       .arg(
           arg!([match]
@@ -59,6 +61,10 @@ pub fn run_cli() -> Result<Cli> {
     let all = matches.get_one::<bool>("all").unwrap().to_owned();
     let group = all || matches.get_one::<bool>("group").unwrap().to_owned();
     let git = all || matches.get_one::<bool>("git").unwrap().to_owned();
+    let skip_lockfiles = matches
+        .get_one::<bool>("skip-lockfiles")
+        .unwrap()
+        .to_owned();
 
     let exclude = if let Some(globs) = matches.get_one::<String>("exclude") {
         globs
@@ -81,7 +87,12 @@ pub fn run_cli() -> Result<Cli> {
     let cli = Cli {
         dir: dir.to_string(),
         num,
-        display_options: DisplayOptions { all, group, git },
+        display_options: DisplayOptions {
+            all,
+            group,
+            git,
+            skip_lockfiles,
+        },
         exclude,
         matches,
     };

--- a/src/display.rs
+++ b/src/display.rs
@@ -38,11 +38,10 @@ pub fn display_info(
     let mut grouped_files: HashMap<FileType, Vec<File>> = HashMap::new();
 
     for file in files.iter() {
-        if let Some(x) = grouped_files.get_mut(&file.clone().get_file_type()) {
-            x.push(file.clone());
-        } else {
-            grouped_files.insert(file.clone().get_file_type(), vec![file.clone()]);
-        }
+        grouped_files
+            .entry(file.file_type)
+            .or_insert_with(|| Vec::new())
+            .push(file.to_owned());
     }
     println!(
         "{} {}\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     }
     let overrides = builder.build().unwrap();
 
-    let mut files = get_files(dir, overrides);
+    let mut files = get_files(dir, overrides, &cli.display_options.skip_lockfiles);
 
     let total_commits = if cli.display_options.git || cli.display_options.all {
         add_git_info(&mut files, dir)


### PR DESCRIPTION
## Description

This PR adds the `--skip-lockfile` flag to remove lockfiles like `Cargo.lock`, `pnpm-lock.yaml` or others from the analysis. It also groups them if they should not be skipped.

Closes #4 